### PR TITLE
Fix EB frontend build script portability and enforce LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Keep deployment-critical files in Unix format for EB Linux instances.
+*.sh text eol=lf
+Procfile text eol=lf
+.ebextensions/*.config text eol=lf

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nomz — NYC Restaurant Discovery Platform
 
 [![Build Status](https://app.travis-ci.com/gcivil-nyu-org/team3-mon-spring26.svg?branch=develop)](https://app.travis-ci.com/gcivil-nyu-org/team3-mon-spring26)
-[![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team3-mon-spring26/badge.svg?branch=develop)](https://coveralls.io/github/gcivil-nyu-org/team3-mon-spring26?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/team3-mon-spring26/badge.svg?branch=production)](https://coveralls.io/github/gcivil-nyu-org/team3-mon-spring26?branch=production)
 
 Nomz is a full-stack web application for discovering, reviewing, and managing NYC restaurants. It combines real-time NYC Open Data ingestion, a multi-factor composite scoring system, personalized recommendations, and social features like friend chat and shared restaurant lists.
 

--- a/scripts/eb_build_frontend.sh
+++ b/scripts/eb_build_frontend.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Elastic Beanstalk: produce a fresh frontend/dist on every deploy.
-# If npm/node is unavailable or the build fails, falls back to the committed
+# If npm/node is unavailable or the build fails, fall back to the committed
 # frontend/dist that ships in the deployment archive.
 set -euo pipefail
 
@@ -13,7 +13,6 @@ if [[ ! -d "${FRONTEND}" ]]; then
 fi
 
 # ---- Attempt a fresh Vite build (best-effort) ----------------------------
-build_ok=0
 if [[ -f "${FRONTEND}/package.json" ]]; then
   if ! command -v npm >/dev/null 2>&1; then
     if command -v dnf >/dev/null 2>&1; then
@@ -24,11 +23,12 @@ if [[ -f "${FRONTEND}/package.json" ]]; then
   fi
 
   if command -v npm >/dev/null 2>&1; then
-    # EB often sets NODE_ENV=production; that makes npm skip devDependencies, so Vite is missing.
+    # EB often sets NODE_ENV=production; that makes npm skip devDependencies,
+    # so Vite is missing.
     unset NODE_ENV || true
     export NPM_CONFIG_PRODUCTION=false
 
-    # Back up the committed dist so we can restore it if the build fails.
+    # Back up committed dist so we can restore it if the build fails.
     if [[ -d "${FRONTEND}/dist" ]]; then
       cp -a "${FRONTEND}/dist" "${FRONTEND}/dist_backup"
     fi
@@ -44,24 +44,23 @@ if [[ -f "${FRONTEND}/package.json" ]]; then
       fi
       npm run build
     ); then
-      build_ok=1
       rm -rf "${FRONTEND}/dist_backup"
       echo "eb_build_frontend: fresh Vite build succeeded."
     else
-      echo "eb_build_frontend: Vite build FAILED — restoring committed dist."
+      echo "eb_build_frontend: Vite build failed - restoring committed dist."
       rm -rf "${FRONTEND}/dist"
       if [[ -d "${FRONTEND}/dist_backup" ]]; then
         mv "${FRONTEND}/dist_backup" "${FRONTEND}/dist"
       fi
     fi
   else
-    echo "eb_build_frontend: npm not available — using committed dist."
+    echo "eb_build_frontend: npm not available - using committed dist."
   fi
 fi
 
 # ---- Verify final state --------------------------------------------------
 if [[ ! -f "${FRONTEND}/dist/index.html" ]]; then
-  echo "eb_build_frontend: ERROR frontend/dist/index.html missing. Ensure the dist is committed to git."
+  echo "eb_build_frontend: ERROR frontend/dist/index.html missing. Ensure dist is committed."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
This PR hardens Elastic Beanstalk deploy script portability and prevents line-ending regressions from Windows checkouts.

### Changes
- Updated `scripts/eb_build_frontend.sh` to be shell-portable and ASCII-safe.
- Removed an unused variable in the script (`build_ok`).
- Added `.gitattributes` to enforce LF for deployment-critical files:
  - `*.sh`
  - `Procfile`
  - `.ebextensions/*.config`

## Why
Recent EB deploy failures occurred in `02_build_frontend` due to shell parsing issues consistent with non-Unix script encoding/line endings. Enforcing LF at the repo level prevents future regressions.

## Validation
- `black --check .` ✅
- `flake8 .` ✅
- `.travis.yml` reviewed and unchanged in this branch ✅