### PR TITLE
ci: isolate develop and production deploys by branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,33 +42,48 @@ script:
 # Send coverage to Coveralls
 after_success:
   - coverage xml
-  - coveralls 
+  - coveralls
 
 # IMPORTANT:
 # Do not build frontend in Travis deploy job. Building in CI mutates the working
 # tree and can produce oversized/corrupt EB bundles.
 
-# Deploy to AWS Elastic Beanstalk on production branch
+# Dual-deploy: strict branch isolation.
+#   develop -> nomz-dev  (staging AWS account 709436855295, nomzdev.dpdns.org)
+#   production -> nomz-prod (production AWS account 554903866296, nomz.dpdns.org)
+# Per-branch credentials keep the two AWS accounts fully separate.
 deploy:
-  provider: elasticbeanstalk
-  skip_cleanup: true
-  access_key_id: $AWS_ACCESS_KEY_ID
-  secret_access_key: $AWS_SECRET_ACCESS_KEY
-  region: us-east-1
-  app: nomz-app
-  env: nomz-prod
-  bucket_name: nomz-static-files-friend-2026
-  bucket_path: deployments
-  on:
-    branch: develop
-    condition: $TRAVIS_TEST_RESULT = 0  # only deploy if tests pass
+  - provider: elasticbeanstalk
+    skip_cleanup: true
+    access_key_id: $AWS_DEVELOP_ACCESS_KEY_ID
+    secret_access_key: $AWS_DEVELOP_SECRET_ACCESS_KEY
+    region: us-east-1
+    app: nomz-app
+    env: nomz-dev
+    bucket_name: nomz-static-files-friend2-dev
+    bucket_path: deployments
+    on:
+      branch: develop
+      condition: $TRAVIS_TEST_RESULT = 0 && $TRAVIS_PULL_REQUEST = false
 
-# Branches to build
+  - provider: elasticbeanstalk
+    skip_cleanup: true
+    access_key_id: $AWS_PRODUCTION_ACCESS_KEY_ID
+    secret_access_key: $AWS_PRODUCTION_SECRET_ACCESS_KEY
+    region: us-east-1
+    app: nomz-app
+    env: nomz-prod
+    bucket_name: nomz-static-files-friend-2026
+    bucket_path: deployments
+    on:
+      branch: production
+      condition: $TRAVIS_TEST_RESULT = 0 && $TRAVIS_PULL_REQUEST = false
+
+# Branches to build (main is deprecated and intentionally excluded)
 branches:
   only:
     - develop
     - production
-    - main
 
 # Notifications (optional)
 notifications:


### PR DESCRIPTION
## Summary

- Split the single Travis `deploy:` block into **two** Elastic Beanstalk deploys with strict branch isolation:
  - `develop` → `nomz-dev` (staging AWS account `709436855295`, bucket `nomz-static-files-friend2-dev`, URL `nomzdev.dpdns.org`) using `AWS_DEVELOP_ACCESS_KEY_ID` / `AWS_DEVELOP_SECRET_ACCESS_KEY`
  - `production` → `nomz-prod` (prod AWS account `554903866296`, bucket `nomz-static-files-friend-2026`, URL `nomz.dpdns.org`) using `AWS_PRODUCTION_ACCESS_KEY_ID` / `AWS_PRODUCTION_SECRET_ACCESS_KEY`
- Added `$TRAVIS_PULL_REQUEST = false` to both deploy conditions so PR builds cannot deploy.
- Removed the deprecated `main` branch from `branches.only` — `main` will no longer build.

## Why

Current `.travis.yml` on `develop` has a single deploy block that says `branch: develop` but `env: nomz-prod` — which is why `nomz-prod` is running version `travis-6ec3927...`, a commit that exists only on `origin/develop`. Develop merges were deploying to the production environment.

## ⚠️ Before merging this PR

**Set these four environment variables in Travis CI repo settings** (Settings → Environment Variables, mark as hidden):

- `AWS_DEVELOP_ACCESS_KEY_ID` (from AWS account `709436855295`)
- `AWS_DEVELOP_SECRET_ACCESS_KEY` (from AWS account `709436855295`)
- `AWS_PRODUCTION_ACCESS_KEY_ID` (from AWS account `554903866296`)
- `AWS_PRODUCTION_SECRET_ACCESS_KEY` (from AWS account `554903866296`)

If these are missing when this PR merges, the first `develop` build will pass tests but fail at the deploy step.

The old `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` can be deleted after the first successful deploy under the new config.

## Test plan

- [ ] Four Travis env vars set before merge
- [ ] This PR builds on Travis (tests should pass; no deploy because PR build)
- [ ] After merge to `develop`: Travis runs the `nomz-dev` deploy block only; `nomz-prod` version is unchanged
- [ ] `nomzdev.dpdns.org` reflects the new merge commit SHA
- [ ] Follow-up PR `develop → production` deploys only to `nomz-prod`
- [ ] A push to `main` triggers no Travis build

## Out of scope (follow-up)

- `.ebextensions/django.config` `02_build_frontend` is not `leader_only: true`; on the load-balanced `nomz-dev` every instance runs the Vite build in parallel. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)