### PR TITLE
chore: ignore OS cruft, editor swaps, and Claude Code artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,4 +220,17 @@ __marimo__/
 
 # AWS credentials helper (contains secrets)
 aws-config.ps1
+
+# OS cruft
 .DS_Store
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Editor swap / backup files
+*.swp
+*.swo
+*~
+
+# Claude Code per-user workflow artifacts
+.claude/


### PR DESCRIPTION
## Summary

Adds three categories to `.gitignore`:

- **Windows OS cruft**: `Thumbs.db`, `ehthumbs.db`, `Desktop.ini` (complement to the existing `.DS_Store` for Mac)
- **Editor swap/backup files**: `*.swp`, `*.swo`, `*~` (Vim, emacs)
- **Claude Code artifacts**: `.claude/` (per-user local workflow state; should never be committed)

## Scope

Intentionally conservative — only appends. Does not touch:
- `node_modules/` (already tracked in the repo by design)
- `image/` (intent unclear — leaving for the author to decide)
- `frontend/dist/` (intentionally committed as EB fallback; comment in file preserves this)

## Test plan

- [ ] `.claude/settings.local.json` no longer appears in `git status` for contributors using Claude Code
- [ ] Merge into `develop`, then fold into the next `develop → production` PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)