### PR TITLE
fix(eb): resolve unresolved merge conflict in .ebextensions/django.config

### DIFF
--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -44,10 +44,6 @@ container_commands:
     leader_only: true
   # Run on every instance so ASG members all get the same frontend/dist (not leader_only).
   02_build_frontend:
-<<<<<<< HEAD
-    # Skip server-side frontend build during bootstrap.
-=======
->>>>>>> 933abc0b (Fix: Enable frontend build during Elastic Beanstalk deployment)
     command: bash scripts/eb_build_frontend.sh
   03_collectstatic:
     command: python manage.py collectstatic --noinput


### PR DESCRIPTION
## THE actual root cause of the blank sites

Commit \`933abc0b\` — "Fix: Enable frontend build during Elastic Beanstalk deployment" — landed the \`02_build_frontend\` command but **left the \`<<<<<<<\` HEAD / \`>>>>>>>\` conflict markers in place in [.ebextensions/django.config](.ebextensions/django.config) (lines 47–50 before this PR)**.

Every EB deploy since has failed YAML validation and auto-rolled back. Fortunately we just surfaced it with a manual deploy:

\`\`\`
2026-04-24 05:02:21    ERROR   The configuration file .ebextensions/django.config in application version app-67d7-260424_010210296333 contains invalid YAML or JSON. YAML exception: Invalid Yaml: while scanning a simple key
 in 'reader', line 47, column 1:
    <<<<<<< HEAD
    ^
could not find expected ':'
2026-04-24 05:02:21    ERROR   Failed to deploy application.
\`\`\`

That's why \`eb status nomz-dev\` has been stuck on the April 20 version (\`app-c21f-…\`) despite multiple deploy attempts: every new version gets uploaded, fails validation, rollback. Travis reports "passed" because it only waits for the **CreateApplicationVersion** upload to succeed; the environment update happens asynchronously and fails silently from Travis's perspective.

This also explains why PRs #191 / #195 / #196 didn't visibly help — even if the Travis deploy step had worked perfectly, EB was always going to reject the ZIP.

## Fix

- Remove the conflict markers.
- Remove the misleading \`# Skip server-side frontend build during bootstrap.\` comment (the script actually runs the build; the comment was pre-merge wishful thinking).

\`\`\`diff
   # Run on every instance so ASG members all get the same frontend/dist (not leader_only).
   02_build_frontend:
-<<<<<<< HEAD
-    # Skip server-side frontend build during bootstrap.
-=======
->>>>>>> 933abc0b (Fix: Enable frontend build during Elastic Beanstalk deployment)
     command: bash scripts/eb_build_frontend.sh
\`\`\`

## Test plan

- [ ] Merge triggers Travis build on develop
- [ ] #196's \`before_deploy\` prints "configuring deploy for nomz-dev"
- [ ] \`Run deployment\` emits real EB upload activity
- [ ] \`eb status nomz-dev --profile gurleen-aws\` now shows a fresh version label (post-04-24 timestamp) and **does not roll back**
- [ ] https://www.nomzdev.dpdns.org/ serves \`index-B5X0KXV3.js\` and the JS asset returns 200
- [ ] Follow up with develop → production PR for nomz-prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)